### PR TITLE
Fix anime episodes, add new season tags, improve UI

### DIFF
--- a/client/components/AnimeCard.tsx
+++ b/client/components/AnimeCard.tsx
@@ -9,6 +9,7 @@ export interface AnimeSummary {
   rating?: number | null; // 0-10
   subDub?: "SUB" | "DUB" | "SUB/DUB" | null;
   genres?: string[];
+  isNewSeason?: boolean;
 }
 
 export function AnimeCard({ anime }: { anime: AnimeSummary }) {

--- a/client/components/AnimeCard.tsx
+++ b/client/components/AnimeCard.tsx
@@ -40,9 +40,14 @@ export function AnimeCard({ anime }: { anime: AnimeSummary }) {
         <div className="text-xs text-foreground/60">
           {anime.type ?? ""} {anime.year ? `• ${anime.year}` : ""}
         </div>
-        {anime.genres && anime.genres.length > 0 && (
+        {(anime.genres && anime.genres.length > 0) || anime.isNewSeason ? (
           <div className="flex flex-wrap gap-1">
-            {anime.genres.slice(0, 3).map((g) => (
+            {anime.isNewSeason && (
+              <span className="rounded bg-yellow-400/90 px-1.5 py-0.5 text-[10px] font-semibold text-black">
+                New Season
+              </span>
+            )}
+            {anime.genres?.slice(0, 3).map((g) => (
               <span
                 key={g}
                 className="rounded bg-accent px-1.5 py-0.5 text-[10px] text-accent-foreground/80"
@@ -51,7 +56,7 @@ export function AnimeCard({ anime }: { anime: AnimeSummary }) {
               </span>
             ))}
           </div>
-        )}
+        ) : null}
       </div>
     </Link>
   );

--- a/client/lib/anime.ts
+++ b/client/lib/anime.ts
@@ -9,6 +9,7 @@ export interface ApiAnimeSummary {
   genres?: string[];
   synopsis?: string;
   seasons?: { id: number; number: number; title?: string }[];
+  isNewSeason?: boolean;
 }
 
 export async function fetchTrending(): Promise<ApiAnimeSummary[]> {

--- a/client/lib/anime.ts
+++ b/client/lib/anime.ts
@@ -203,28 +203,23 @@ export async function fetchEpisodes(
 }
 
 function normalizeEpisodesResponse(data: any): EpisodesResponse {
-  const episodes = (data.episodes || data.results || data.data || []).map(
-    (ep: any) => {
-      const number =
-        ep.number ??
-        ep.episode ??
-        ep.episode_number ??
-        ep.ep ??
-        ep.ep_num ??
-        ep.mal_id ??
-        null;
-      const title =
-        ep.title || ep.name || ep.episodeTitle || ep.title_english || undefined;
-      const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;
-      const id = ep.id ?? ep.mal_id ?? `${ep.mal_id ?? ""}-${number ?? ""}`;
-      return {
-        id: String(id),
-        number: typeof number === "number" ? number : Number(number) || 0,
-        title,
-        air_date,
-      };
-    },
-  );
+  const base = data.episodes || data.results || data.data || [];
+  const episodes = base.map((ep: any, idx: number) => {
+    const number =
+      ep.number ?? ep.episode ?? ep.episode_number ?? ep.ep ?? ep.ep_num ?? null;
+    const title =
+      ep.title || ep.name || ep.episodeTitle || ep.title_english || undefined;
+    const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;
+    const n = typeof number === "number" ? number : Number(number) || 0;
+    const finalNum = n > 0 ? n : idx + 1;
+    const id = ep.id ?? ep.mal_id ?? `${ep.mal_id ?? ""}-${finalNum}`;
+    return {
+      id: String(id),
+      number: finalNum,
+      title,
+      air_date,
+    };
+  });
 
   // Normalize pagination to include last_visible_page if possible
   const pagination = data.pagination || data.meta || null;

--- a/client/lib/anime.ts
+++ b/client/lib/anime.ts
@@ -187,50 +187,16 @@ export async function fetchEpisodes(
   id: number,
   page = 1,
 ): Promise<EpisodesResponse> {
-  const ALT_BASE = "https://api3.anime-dexter-live.workers.dev";
-  // Try server endpoint first
   try {
     const res = await fetch(`/api/anime/episodes/${id}?page=${page}`);
     if (res.ok) {
       const data = await res.json();
       return normalizeEpisodesResponse(data);
     }
-    console.warn("server episodes returned non-ok", res.status);
+    console.error("episodes endpoint returned", res.status);
   } catch (e) {
-    console.warn("server episodes fetch failed", e);
+    console.error("episodes fetch failed", e);
   }
-
-  // Fallback: try dexter directly from client (CORS allowing)
-  try {
-    const dexterUrl = `${ALT_BASE}/anime/${id}/episodes${page > 1 ? `?page=${page}` : ""}`;
-    const r = await fetch(dexterUrl);
-    if (r.ok) {
-      const j = await r.json();
-      return normalizeEpisodesResponse({
-        episodes: j.data || j.results || j.episodes || j,
-      });
-    }
-    console.warn("dexter direct returned non-ok", r.status);
-  } catch (e) {
-    console.warn("dexter direct fetch failed", e);
-  }
-
-  // Final fallback: try Jikan directly
-  try {
-    const jikanUrl = `https://api.jikan.moe/v4/anime/${id}/episodes?page=${page}`;
-    const rj = await fetch(jikanUrl);
-    if (rj.ok) {
-      const j = await rj.json();
-      return normalizeEpisodesResponse({
-        episodes: j.data || j.episodes || [],
-        pagination: j.pagination || null,
-      });
-    }
-    console.warn("jikan direct returned non-ok", rj.status);
-  } catch (e) {
-    console.warn("jikan direct fetch failed", e);
-  }
-
   return { episodes: [], pagination: null };
 }
 

--- a/client/lib/anime.ts
+++ b/client/lib/anime.ts
@@ -206,7 +206,12 @@ function normalizeEpisodesResponse(data: any): EpisodesResponse {
   const base = data.episodes || data.results || data.data || [];
   const episodes = base.map((ep: any, idx: number) => {
     const number =
-      ep.number ?? ep.episode ?? ep.episode_number ?? ep.ep ?? ep.ep_num ?? null;
+      ep.number ??
+      ep.episode ??
+      ep.episode_number ??
+      ep.ep ??
+      ep.ep_num ??
+      null;
     const title =
       ep.title || ep.name || ep.episodeTitle || ep.title_english || undefined;
     const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;

--- a/client/lib/anime.ts
+++ b/client/lib/anime.ts
@@ -8,6 +8,7 @@ export interface ApiAnimeSummary {
   subDub?: "SUB" | "DUB" | "SUB/DUB" | null;
   genres?: string[];
   synopsis?: string;
+  seasons?: { id: number; number: number; title?: string }[];
 }
 
 export async function fetchTrending(): Promise<ApiAnimeSummary[]> {

--- a/client/pages/Anime.tsx
+++ b/client/pages/Anime.tsx
@@ -36,7 +36,8 @@ export default function AnimePage() {
           setStreams([]);
         } else {
           setInfo(i);
-          const baseSeason = i.seasons && i.seasons.length > 0 ? i.seasons[0].id : id;
+          const baseSeason =
+            i.seasons && i.seasons.length > 0 ? i.seasons[0].id : id;
           setSelectedId(baseSeason);
           const s = await fetchStreams(baseSeason).catch(() => []);
           setStreams(s || []);
@@ -195,7 +196,10 @@ export default function AnimePage() {
                   >
                     {seasons.length > 0 ? (
                       seasons.map((s, i) => (
-                        <option key={s.id} value={s.id}>{`Season ${i + 1}`}</option>
+                        <option
+                          key={s.id}
+                          value={s.id}
+                        >{`Season ${i + 1}`}</option>
                       ))
                     ) : (
                       <option value={selectedId ?? id}>Season 1</option>
@@ -242,7 +246,8 @@ export default function AnimePage() {
                         window.open(streams[0].url, "_blank", "noreferrer");
                       } else {
                         toast("Streaming not available", {
-                          description: "Streaming providers not reported for this title.",
+                          description:
+                            "Streaming providers not reported for this title.",
                           duration: 2500,
                         });
                       }

--- a/client/pages/Anime.tsx
+++ b/client/pages/Anime.tsx
@@ -15,9 +15,9 @@ export default function AnimePage() {
   const params = useParams();
   const id = Number(params.id);
   const [info, setInfo] = useState<ApiAnimeSummary | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [episodes, setEpisodes] = useState<EpisodeItem[]>([]);
   const [episodesPagination, setEpisodesPagination] = useState<any>(null);
-  const [seasonPage, setSeasonPage] = useState<number>(1); // default season 1
   const [streams, setStreams] = useState<StreamLink[]>([]);
   const [loadingInfo, setLoadingInfo] = useState(true);
   const [loadingEpisodes, setLoadingEpisodes] = useState(true);
@@ -26,22 +26,29 @@ export default function AnimePage() {
     (async () => {
       setLoadingInfo(true);
       try {
-        const [i, s] = await Promise.all([
-          fetchAnimeInfo(id),
-          fetchStreams(id).catch(() => []),
-        ]);
+        const i = await fetchAnimeInfo(id);
         if (!i) {
           toast("Failed to load anime info", {
             description: "Could not fetch anime details from the API.",
           });
+          setInfo(null);
+          setSelectedId(id);
+          setStreams([]);
+        } else {
+          setInfo(i);
+          const baseSeason = i.seasons && i.seasons.length > 0 ? i.seasons[0].id : id;
+          setSelectedId(baseSeason);
+          const s = await fetchStreams(baseSeason).catch(() => []);
+          setStreams(s || []);
         }
-        setInfo(i);
-        setStreams(s || []);
       } catch (e) {
         console.error(e);
         toast("Network error", {
           description: "Failed to fetch anime data. Please try again later.",
         });
+        setInfo(null);
+        setSelectedId(id);
+        setStreams([]);
       } finally {
         setLoadingInfo(false);
       }
@@ -49,10 +56,11 @@ export default function AnimePage() {
   }, [id]);
 
   useEffect(() => {
+    if (!selectedId) return;
     (async () => {
       setLoadingEpisodes(true);
       try {
-        const resp = await fetchEpisodes(id, seasonPage);
+        const resp = await fetchEpisodes(selectedId, 1);
         if (!resp || !Array.isArray(resp.episodes)) {
           toast("Failed to load episodes", {
             description: "Could not fetch episodes for this season.",
@@ -74,10 +82,16 @@ export default function AnimePage() {
         setLoadingEpisodes(false);
       }
     })();
-  }, [id, seasonPage]);
+  }, [selectedId]);
 
   const banner = useMemo(() => info?.image ?? "", [info]);
   const loading = loadingInfo || loadingEpisodes;
+  const seasons = info?.seasons || [];
+  const currentSeasonIndex = useMemo(() => {
+    if (!seasons || !selectedId) return 0;
+    const idx = seasons.findIndex((s) => s.id === selectedId);
+    return idx >= 0 ? idx : 0;
+  }, [seasons, selectedId]);
 
   return (
     <Layout>
@@ -96,21 +110,21 @@ export default function AnimePage() {
       ) : info || episodes.length > 0 ? (
         <div>
           {info && (
-            <div className="relative">
-              <div className="absolute inset-0 -z-10">
+            <section className="relative overflow-hidden">
+              <div className="relative aspect-[16/6] w-full">
                 <img
                   src={banner}
                   alt="banner"
-                  className="h-full w-full object-cover opacity-30 blur-sm"
+                  className="h-full w-full object-cover opacity-40"
                 />
-                <div className="absolute inset-0 bg-gradient-to-b from-background/30 to-background" />
+                <div className="absolute inset-0 bg-gradient-to-b from-background/10 via-background/30 to-background" />
               </div>
-              <div className="container mx-auto px-4 py-6 md:py-10">
+              <div className="container mx-auto px-4 py-6 md:py-8">
                 <div className="flex flex-col gap-6 md:flex-row">
                   <img
                     src={info.image}
                     alt={info.title}
-                    className="h-[300px] w-[220px] rounded-md border object-cover"
+                    className="h-[260px] w-[200px] rounded-md border object-cover"
                   />
                   <div className="flex-1">
                     <h1 className="text-2xl font-bold md:text-4xl">
@@ -119,7 +133,7 @@ export default function AnimePage() {
                     <div className="mt-2 text-sm text-foreground/70">
                       {info.type} {info.year ? `• ${info.year}` : ""}
                       {info.rating != null && (
-                        <span className="ml-2 rounded bg-black/30 px-2 py-0.5 text-xs">
+                        <span className="ml-2 rounded bg-black/20 px-2 py-0.5 text-xs">
                           ⭐ {info.rating.toFixed(1)}
                         </span>
                       )}
@@ -144,7 +158,7 @@ export default function AnimePage() {
                   </div>
                 </div>
               </div>
-            </div>
+            </section>
           )}
 
           <div className="container mx-auto px-4 pb-10">
@@ -174,28 +188,18 @@ export default function AnimePage() {
                 <label className="text-sm font-medium">Season</label>
                 <div className="relative inline-block">
                   <select
-                    value={seasonPage}
-                    onChange={(e) => setSeasonPage(Number(e.target.value))}
+                    value={selectedId ?? undefined}
+                    onChange={(e) => setSelectedId(Number(e.target.value))}
                     className="appearance-none rounded-md border bg-background px-4 py-2 pr-8 text-sm transition-shadow duration-150 hover:shadow-sm focus:shadow-md focus:outline-none"
                     aria-label="Select season"
                   >
-                    {(() => {
-                      const last =
-                        episodesPagination?.last_visible_page ??
-                        Math.max(
-                          1,
-                          Math.ceil(
-                            ((episodesPagination?.items?.total as number) ||
-                              episodes.length) / 24,
-                          ),
-                        );
-                      const count = Math.max(1, Number(last || 1));
-                      return Array.from({ length: count }).map((_, i) => (
-                        <option key={i} value={i + 1}>
-                          {`Season ${i + 1}`}
-                        </option>
-                      ));
-                    })()}
+                    {seasons.length > 0 ? (
+                      seasons.map((s, i) => (
+                        <option key={s.id} value={s.id}>{`Season ${i + 1}`}</option>
+                      ))
+                    ) : (
+                      <option value={selectedId ?? id}>Season 1</option>
+                    )}
                   </select>
                   <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
                     <svg

--- a/client/pages/Anime.tsx
+++ b/client/pages/Anime.tsx
@@ -111,7 +111,7 @@ export default function AnimePage() {
         <div>
           {info && (
             <section className="relative overflow-hidden">
-              <div className="relative aspect-[16/6] w-full">
+              <div className="relative h-48 md:h-56 lg:h-64 w-full">
                 <img
                   src={banner}
                   alt="banner"
@@ -119,15 +119,15 @@ export default function AnimePage() {
                 />
                 <div className="absolute inset-0 bg-gradient-to-b from-background/10 via-background/30 to-background" />
               </div>
-              <div className="container mx-auto px-4 py-6 md:py-8">
+              <div className="container mx-auto px-4 py-4 md:py-6">
                 <div className="flex flex-col gap-6 md:flex-row">
                   <img
                     src={info.image}
                     alt={info.title}
-                    className="h-[260px] w-[200px] rounded-md border object-cover"
+                    className="h-[220px] w-[170px] rounded-md border object-cover"
                   />
                   <div className="flex-1">
-                    <h1 className="text-2xl font-bold md:text-4xl">
+                    <h1 className="text-xl font-bold md:text-3xl">
                       {info.title}
                     </h1>
                     <div className="mt-2 text-sm text-foreground/70">

--- a/client/pages/Anime.tsx
+++ b/client/pages/Anime.tsx
@@ -237,15 +237,16 @@ export default function AnimePage() {
                   <button
                     key={ep.id + "-" + ep.number}
                     className="rounded border px-3 py-2 text-left text-sm hover:bg-accent"
-                    onClick={() =>
-                      toast("Streaming not available in-app", {
-                        description:
-                          streams.length > 0
-                            ? "Use the streaming links above to watch legally."
-                            : "Streaming providers not reported for this title.",
-                        duration: 3000,
-                      })
-                    }
+                    onClick={() => {
+                      if (streams.length > 0) {
+                        window.open(streams[0].url, "_blank", "noreferrer");
+                      } else {
+                        toast("Streaming not available", {
+                          description: "Streaming providers not reported for this title.",
+                          duration: 2500,
+                        });
+                      }
+                    }}
                   >
                     <div className="font-medium">Episode {ep.number}</div>
                     {ep.title && (

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -4,7 +4,10 @@ const JIKAN_BASE = "https://api.jikan.moe/v4";
 
 // Simple in-memory cache for episodes to mitigate upstream rate limits
 const EPISODES_TTL_MS = 3 * 60 * 1000;
-const episodesCache: Record<string, { at: number; data: { episodes: any[]; pagination: any } }> = {};
+const episodesCache: Record<
+  string,
+  { at: number; data: { episodes: any[]; pagination: any } }
+> = {};
 
 function normalizeBaseTitle(title: string) {
   let s = String(title || "").trim();
@@ -25,8 +28,11 @@ function mapAnime(a: any) {
   const nowYear = new Date().getFullYear();
   const year = a.year ?? a.aired?.prop?.from?.year ?? null;
   const airing = a.airing === true || a.status === "Currently Airing";
-  const seasonMarker = /(season\s*\d+|part\s*\d+|cour\s*\d+|final\s*season|\bii\b|\biii\b|\biv\b|\bv\b|\bvi\b|\bvii\b|\bviii\b|\bix\b|\bx\b|\d+\s*$)/i.test(originalTitle);
-  const isNewSeason = seasonMarker && (airing || (year === nowYear));
+  const seasonMarker =
+    /(season\s*\d+|part\s*\d+|cour\s*\d+|final\s*season|\bii\b|\biii\b|\biv\b|\bv\b|\bvi\b|\bvii\b|\bviii\b|\bix\b|\bx\b|\d+\s*$)/i.test(
+      originalTitle,
+    );
+  const isNewSeason = seasonMarker && (airing || year === nowYear);
   return {
     id: a.mal_id,
     title: baseTitle,
@@ -101,25 +107,31 @@ export const getInfo: RequestHandler = async (req, res) => {
       return chosen ? { id: chosen.mal_id, title: chosen.name } : null;
     }
 
-    async function buildSeasonsChain(startData: any): Promise<{ ids: number[]; titles: Record<number, string> }> {
+    async function buildSeasonsChain(
+      startData: any,
+    ): Promise<{ ids: number[]; titles: Record<number, string> }> {
       const seen = new Set<number>();
       const titles: Record<number, string> = {};
       let current = startData;
       let currentId = Number(current.mal_id);
-      titles[currentId] = current.title || current.title_english || current.title_japanese;
+      titles[currentId] =
+        current.title || current.title_english || current.title_japanese;
 
       // Walk back to base via prequels
       const back: number[] = [];
       let node = current;
       for (let i = 0; i < 8; i++) {
-        const preRel = node.relations?.find?.((r: any) => r.relation === "Prequel");
+        const preRel = node.relations?.find?.(
+          (r: any) => r.relation === "Prequel",
+        );
         const pre = pickRelation(preRel);
         if (!pre || seen.has(pre.id)) break;
         seen.add(pre.id);
         back.push(pre.id);
         const full = await fetchByMal(String(pre.id));
         if (!full) break;
-        titles[pre.id] = full.title || full.title_english || full.title_japanese;
+        titles[pre.id] =
+          full.title || full.title_english || full.title_japanese;
         node = full;
       }
 
@@ -129,13 +141,16 @@ export const getInfo: RequestHandler = async (req, res) => {
       // Walk forward from current/base via sequels
       node = current;
       for (let i = 0; i < 8; i++) {
-        const seqRel = node.relations?.find?.((r: any) => r.relation === "Sequel");
+        const seqRel = node.relations?.find?.(
+          (r: any) => r.relation === "Sequel",
+        );
         const seq = pickRelation(seqRel);
         if (!seq || seen.has(seq.id)) break;
         seen.add(seq.id);
         const full = await fetchByMal(String(seq.id));
         if (!full) break;
-        titles[seq.id] = full.title || full.title_english || full.title_japanese;
+        titles[seq.id] =
+          full.title || full.title_english || full.title_japanese;
         chain.push(seq.id);
         node = full;
       }
@@ -149,7 +164,13 @@ export const getInfo: RequestHandler = async (req, res) => {
       if (data) {
         const base = mapAnime(data);
         const chain = await buildSeasonsChain(data).catch(() => null);
-        const seasons = chain ? chain.ids.map((id, i) => ({ id, number: i + 1, title: normalizeBaseTitle(chain.titles[id] || "") })) : [];
+        const seasons = chain
+          ? chain.ids.map((id, i) => ({
+              id,
+              number: i + 1,
+              title: normalizeBaseTitle(chain.titles[id] || ""),
+            }))
+          : [];
         return res.json({ ...base, seasons });
       }
     }
@@ -190,7 +211,13 @@ export const getInfo: RequestHandler = async (req, res) => {
             if (data) {
               const base = mapAnime(data);
               const chain = await buildSeasonsChain(data).catch(() => null);
-              const seasons = chain ? chain.ids.map((id, i) => ({ id, number: i + 1, title: normalizeBaseTitle(chain.titles[id] || "") })) : [];
+              const seasons = chain
+                ? chain.ids.map((id, i) => ({
+                    id,
+                    number: i + 1,
+                    title: normalizeBaseTitle(chain.titles[id] || ""),
+                  }))
+                : [];
               return res.json({ ...base, seasons });
             }
           }
@@ -255,7 +282,9 @@ export const getEpisodes: RequestHandler = async (req, res) => {
     }
 
     // 1) Primary: Jikan episodes
-    const primary = await fetchJson(`${JIKAN_BASE}/anime/${id}/episodes?page=${page}`);
+    const primary = await fetchJson(
+      `${JIKAN_BASE}/anime/${id}/episodes?page=${page}`,
+    );
     if (primary.ok) {
       const j = primary.json as any;
       const episodes = (j.data || []).map((ep: any, idx: number) => {
@@ -277,9 +306,12 @@ export const getEpisodes: RequestHandler = async (req, res) => {
 
     // 2) Fallback: derive slug from Jikan title and try a single provider list via Consumet
     const infoRes = await fetchJson(`${JIKAN_BASE}/anime/${id}`);
-    const title = (infoRes.ok && (infoRes.json as any)?.data)
-      ? ((infoRes.json as any).data.title || (infoRes.json as any).data.title_english || (infoRes.json as any).data.title_japanese)
-      : null;
+    const title =
+      infoRes.ok && (infoRes.json as any)?.data
+        ? (infoRes.json as any).data.title ||
+          (infoRes.json as any).data.title_english ||
+          (infoRes.json as any).data.title_japanese
+        : null;
     if (title) {
       const slug = slugify(title);
       const providers = ["gogoanime", "zoro", "animepahe"];
@@ -287,16 +319,27 @@ export const getEpisodes: RequestHandler = async (req, res) => {
         const infoUrl = `https://api.consumet.org/anime/${p}/info/${slug}`;
         const c = await fetchJson(infoUrl, 8000, 0);
         if (c.ok) {
-          const arr = (c.json as any)?.episodes || (c.json as any)?.data?.episodes || (c.json as any)?.results || null;
+          const arr =
+            (c.json as any)?.episodes ||
+            (c.json as any)?.data?.episodes ||
+            (c.json as any)?.results ||
+            null;
           if (Array.isArray(arr) && arr.length > 0) {
             const episodes = arr.map((ep: any) => {
-              const number = ep.number ?? ep.episode ?? ep.ep ?? ep.index ?? null;
-              const title = ep.title || ep.name || ep.episodeTitle || ep.title_english || undefined;
+              const number =
+                ep.number ?? ep.episode ?? ep.ep ?? ep.index ?? null;
+              const title =
+                ep.title ||
+                ep.name ||
+                ep.episodeTitle ||
+                ep.title_english ||
+                undefined;
               const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;
               const eid = ep.id ?? `${id}-${number ?? "0"}`;
               return {
                 id: String(eid),
-                number: typeof number === "number" ? number : Number(number) || 0,
+                number:
+                  typeof number === "number" ? number : Number(number) || 0,
                 title,
                 air_date,
               };
@@ -307,7 +350,11 @@ export const getEpisodes: RequestHandler = async (req, res) => {
               page,
               has_next_page: total > page * perPage,
               last_visible_page: Math.max(1, Math.ceil(total / perPage)),
-              items: { count: Math.min(perPage, total - (page - 1) * perPage), total, per_page: perPage },
+              items: {
+                count: Math.min(perPage, total - (page - 1) * perPage),
+                total,
+                per_page: perPage,
+              },
             };
             const payload = { episodes, pagination };
             episodesCache[cacheKey] = { at: now, data: payload };

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -2,6 +2,10 @@ import { RequestHandler } from "express";
 
 const JIKAN_BASE = "https://api.jikan.moe/v4";
 
+// Simple in-memory cache for episodes to mitigate upstream rate limits
+const EPISODES_TTL_MS = 3 * 60 * 1000;
+const episodesCache: Record<string, { at: number; data: { episodes: any[]; pagination: any } }> = {};
+
 function mapAnime(a: any) {
   const images = a.images?.jpg || a.images?.webp || {};
   return {
@@ -145,23 +149,95 @@ export const getEpisodes: RequestHandler = async (req, res) => {
   try {
     const id = req.params.id;
     const page = Math.max(1, Number(req.query.page || 1) || 1);
-
-    const r = await fetch(`${JIKAN_BASE}/anime/${id}/episodes?page=${page}`);
-    if (!r.ok) {
-      return res.status(r.status).json({ episodes: [], pagination: null });
+    const cacheKey = `${id}:${page}`;
+    const now = Date.now();
+    const cached = episodesCache[cacheKey];
+    if (cached && now - cached.at < EPISODES_TTL_MS) {
+      return res.json(cached.data);
     }
-    const json = await r.json();
 
-    const episodes = (json.data || []).map((ep: any) => ({
-      id: String(ep.mal_id ?? `${id}-${ep.episode ?? ""}`),
-      number:
-        typeof ep.episode === "number" ? ep.episode : Number(ep.episode) || 0,
-      title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
-      air_date: ep.aired || null,
-    }));
+    // Helper: fetch with timeout and simple 429 retry
+    async function fetchJson(url: string, timeoutMs = 8000, retries = 1) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const r = await fetch(url, { signal: controller.signal });
+        if (r.status === 429 && retries > 0) {
+          await new Promise((r) => setTimeout(r, 500));
+          return fetchJson(url, timeoutMs, retries - 1);
+        }
+        if (!r.ok) return { ok: false, status: r.status, json: null } as const;
+        const j = await r.json();
+        return { ok: true, status: r.status, json: j } as const;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
 
-    const pagination = json.pagination || null;
-    return res.json({ episodes, pagination });
+    // 1) Primary: Jikan episodes
+    const primary = await fetchJson(`${JIKAN_BASE}/anime/${id}/episodes?page=${page}`);
+    if (primary.ok) {
+      const j = primary.json as any;
+      const episodes = (j.data || []).map((ep: any) => ({
+        id: String(ep.mal_id ?? `${id}-${ep.episode ?? ""}`),
+        number:
+          typeof ep.episode === "number" ? ep.episode : Number(ep.episode) || 0,
+        title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
+        air_date: ep.aired || null,
+      }));
+      const payload = { episodes, pagination: j.pagination || null };
+      // Cache even empty to avoid hammering the API
+      episodesCache[cacheKey] = { at: now, data: payload };
+      // If we have results, return immediately
+      if (episodes.length > 0) return res.json(payload);
+    }
+
+    // 2) Fallback: derive slug from Jikan title and try a single provider list via Consumet
+    const infoRes = await fetchJson(`${JIKAN_BASE}/anime/${id}`);
+    const title = (infoRes.ok && (infoRes.json as any)?.data)
+      ? ((infoRes.json as any).data.title || (infoRes.json as any).data.title_english || (infoRes.json as any).data.title_japanese)
+      : null;
+    if (title) {
+      const slug = slugify(title);
+      const providers = ["gogoanime", "zoro", "animepahe"];
+      for (const p of providers) {
+        const infoUrl = `https://api.consumet.org/anime/${p}/info/${slug}`;
+        const c = await fetchJson(infoUrl, 8000, 0);
+        if (c.ok) {
+          const arr = (c.json as any)?.episodes || (c.json as any)?.data?.episodes || (c.json as any)?.results || null;
+          if (Array.isArray(arr) && arr.length > 0) {
+            const episodes = arr.map((ep: any) => {
+              const number = ep.number ?? ep.episode ?? ep.ep ?? ep.index ?? null;
+              const title = ep.title || ep.name || ep.episodeTitle || ep.title_english || undefined;
+              const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;
+              const eid = ep.id ?? `${id}-${number ?? "0"}`;
+              return {
+                id: String(eid),
+                number: typeof number === "number" ? number : Number(number) || 0,
+                title,
+                air_date,
+              };
+            });
+            const perPage = 24;
+            const total = arr.length;
+            const pagination = {
+              page,
+              has_next_page: total > page * perPage,
+              last_visible_page: Math.max(1, Math.ceil(total / perPage)),
+              items: { count: Math.min(perPage, total - (page - 1) * perPage), total, per_page: perPage },
+            };
+            const payload = { episodes, pagination };
+            episodesCache[cacheKey] = { at: now, data: payload };
+            return res.json(payload);
+          }
+        }
+      }
+    }
+
+    // 3) No data
+    const empty = { episodes: [], pagination: null };
+    episodesCache[cacheKey] = { at: now, data: empty };
+    return res.json(empty);
   } catch (e: any) {
     res.status(500).json({ error: e?.message || "Episodes failed" });
   }

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -89,13 +89,11 @@ export const getInfo: RequestHandler = async (req, res) => {
       return json.data ?? null;
     }
 
-    function pickRelation(entries: any[] | undefined, kind: "Prequel" | "Sequel") {
-      if (!Array.isArray(entries)) return null;
-      const tv = entries.find((e) => e.type === "anime" && e.entry?.some?.((x: any) => x.type === "TV"));
-      const any = entries[0];
-      const target = tv || any;
-      const entry = target?.entry?.find?.((x: any) => x.type === "TV") || target?.entry?.[0] || null;
-      return entry ? { id: entry.mal_id, title: entry.name } : null;
+    function pickRelation(rel: any) {
+      if (!rel || !Array.isArray(rel.entry)) return null;
+      const tv = rel.entry.find((x: any) => x.type === "TV");
+      const chosen = tv || rel.entry[0];
+      return chosen ? { id: chosen.mal_id, title: chosen.name } : null;
     }
 
     async function buildSeasonsChain(startData: any): Promise<{ ids: number[]; titles: Record<number, string> }> {
@@ -110,7 +108,7 @@ export const getInfo: RequestHandler = async (req, res) => {
       let node = current;
       for (let i = 0; i < 8; i++) {
         const preRel = node.relations?.find?.((r: any) => r.relation === "Prequel");
-        const pre = pickRelation([preRel].filter(Boolean) as any, "Prequel");
+        const pre = pickRelation(preRel);
         if (!pre || seen.has(pre.id)) break;
         seen.add(pre.id);
         back.push(pre.id);
@@ -121,14 +119,13 @@ export const getInfo: RequestHandler = async (req, res) => {
       }
 
       // Base is last back or current
-      const baseId = back.length > 0 ? back[back.length - 1] : currentId;
       const chain: number[] = [...back.reverse(), currentId];
 
       // Walk forward from current/base via sequels
       node = current;
       for (let i = 0; i < 8; i++) {
         const seqRel = node.relations?.find?.((r: any) => r.relation === "Sequel");
-        const seq = pickRelation([seqRel].filter(Boolean) as any, "Sequel");
+        const seq = pickRelation(seqRel);
         if (!seq || seen.has(seq.id)) break;
         seen.add(seq.id);
         const full = await fetchByMal(String(seq.id));

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -6,16 +6,31 @@ const JIKAN_BASE = "https://api.jikan.moe/v4";
 const EPISODES_TTL_MS = 3 * 60 * 1000;
 const episodesCache: Record<string, { at: number; data: { episodes: any[]; pagination: any } }> = {};
 
+function normalizeBaseTitle(title: string) {
+  let s = String(title || "").trim();
+  s = s.replace(/\s*-\s*(Season|Cour|Part)\s*\d+$/i, "");
+  s = s.replace(/\s*\(\s*(Season|Cour|Part)\s*\d+\s*\)$/i, "");
+  s = s.replace(/\s*\b(\d+)(st|nd|rd|th)\s+Season\b.*$/i, "");
+  s = s.replace(/\s*\bSeason\s+\d+(?:\s*Part\s*\d+)?\b.*$/i, "");
+  s = s.replace(/\s*\bFinal Season(?:\s*Part\s*\d+)?\b.*$/i, "");
+  s = s.replace(/\s+(?:II|III|IV|V|VI|VII|VIII|IX|X)$/i, "");
+  s = s.replace(/\s+\d+$/i, "");
+  return s.trim();
+}
+
 function mapAnime(a: any) {
   const images = a.images?.jpg || a.images?.webp || {};
+  const baseTitle = normalizeBaseTitle(
+    a.title || a.title_english || a.title_japanese,
+  );
   return {
     id: a.mal_id,
-    title: a.title || a.title_english || a.title_japanese,
+    title: baseTitle,
     image: images.large_image_url || images.image_url || images.small_image_url,
     type: a.type || undefined,
     year: a.year ?? a.aired?.prop?.from?.year ?? null,
     rating: typeof a.score === "number" ? a.score : null,
-    subDub: "SUB", // Jikan doesn't provide sub/dub; default to SUB
+    subDub: "SUB",
     genres: Array.isArray(a.genres) ? a.genres.map((g: any) => g.name) : [],
     synopsis: a.synopsis || "",
   };
@@ -74,10 +89,67 @@ export const getInfo: RequestHandler = async (req, res) => {
       return json.data ?? null;
     }
 
+    function pickRelation(entries: any[] | undefined, kind: "Prequel" | "Sequel") {
+      if (!Array.isArray(entries)) return null;
+      const tv = entries.find((e) => e.type === "anime" && e.entry?.some?.((x: any) => x.type === "TV"));
+      const any = entries[0];
+      const target = tv || any;
+      const entry = target?.entry?.find?.((x: any) => x.type === "TV") || target?.entry?.[0] || null;
+      return entry ? { id: entry.mal_id, title: entry.name } : null;
+    }
+
+    async function buildSeasonsChain(startData: any): Promise<{ ids: number[]; titles: Record<number, string> }> {
+      const seen = new Set<number>();
+      const titles: Record<number, string> = {};
+      let current = startData;
+      let currentId = Number(current.mal_id);
+      titles[currentId] = current.title || current.title_english || current.title_japanese;
+
+      // Walk back to base via prequels
+      const back: number[] = [];
+      let node = current;
+      for (let i = 0; i < 8; i++) {
+        const preRel = node.relations?.find?.((r: any) => r.relation === "Prequel");
+        const pre = pickRelation([preRel].filter(Boolean) as any, "Prequel");
+        if (!pre || seen.has(pre.id)) break;
+        seen.add(pre.id);
+        back.push(pre.id);
+        const full = await fetchByMal(String(pre.id));
+        if (!full) break;
+        titles[pre.id] = full.title || full.title_english || full.title_japanese;
+        node = full;
+      }
+
+      // Base is last back or current
+      const baseId = back.length > 0 ? back[back.length - 1] : currentId;
+      const chain: number[] = [...back.reverse(), currentId];
+
+      // Walk forward from current/base via sequels
+      node = current;
+      for (let i = 0; i < 8; i++) {
+        const seqRel = node.relations?.find?.((r: any) => r.relation === "Sequel");
+        const seq = pickRelation([seqRel].filter(Boolean) as any, "Sequel");
+        if (!seq || seen.has(seq.id)) break;
+        seen.add(seq.id);
+        const full = await fetchByMal(String(seq.id));
+        if (!full) break;
+        titles[seq.id] = full.title || full.title_english || full.title_japanese;
+        chain.push(seq.id);
+        node = full;
+      }
+
+      return { ids: chain, titles };
+    }
+
     // If numeric id provided, try Jikan directly
     if (/^\d+$/.test(raw)) {
       const data = await fetchByMal(raw);
-      if (data) return res.json(mapAnime(data));
+      if (data) {
+        const base = mapAnime(data);
+        const chain = await buildSeasonsChain(data).catch(() => null);
+        const seasons = chain ? chain.ids.map((id, i) => ({ id, number: i + 1, title: normalizeBaseTitle(chain.titles[id] || "") })) : [];
+        return res.json({ ...base, seasons });
+      }
     }
 
     // Not numeric or initial fetch failed: try searching Jikan by title (replace hyphens with spaces)
@@ -113,7 +185,12 @@ export const getInfo: RequestHandler = async (req, res) => {
           // If we can find mal_id, fetch full from Jikan
           if (ep) {
             const data = await fetchByMal(String(ep));
-            if (data) return res.json(mapAnime(data));
+            if (data) {
+              const base = mapAnime(data);
+              const chain = await buildSeasonsChain(data).catch(() => null);
+              const seasons = chain ? chain.ids.map((id, i) => ({ id, number: i + 1, title: normalizeBaseTitle(chain.titles[id] || "") })) : [];
+              return res.json({ ...base, seasons });
+            }
           }
           // Otherwise try to map consumet info fields
           const title = j?.title || j?.data?.title || j?.name || null;
@@ -121,7 +198,7 @@ export const getInfo: RequestHandler = async (req, res) => {
           if (title) {
             return res.json({
               id: j?.mal_id || null,
-              title,
+              title: normalizeBaseTitle(title),
               image,
               type: j?.type || null,
               year: j?.year || null,
@@ -129,6 +206,7 @@ export const getInfo: RequestHandler = async (req, res) => {
               subDub: null,
               genres: j?.genres || [],
               synopsis: j?.description || j?.data?.description || null,
+              seasons: [],
             });
           }
         } catch (e) {

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -142,161 +142,26 @@ export const getInfo: RequestHandler = async (req, res) => {
 };
 
 export const getEpisodes: RequestHandler = async (req, res) => {
-  const ALT_BASE = "https://api3.anime-dexter-live.workers.dev";
-
-  function fetchWithTimeout(url: string, opts: any = {}, timeout = 7000) {
-    const controller = new AbortController();
-    const idT = setTimeout(() => controller.abort(), timeout);
-    return fetch(url, { signal: controller.signal, ...opts }).finally(() =>
-      clearTimeout(idT),
-    );
-  }
-
-  async function tryFetchJson(url: string) {
-    try {
-      const r = await fetchWithTimeout(url, {}, 7000);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      return await r.json();
-    } catch (e) {
-      // propagate
-      throw e;
-    }
-  }
-
   try {
     const id = req.params.id;
-    const page = Number(req.query.page || 1);
+    const page = Math.max(1, Number(req.query.page || 1) || 1);
 
-    // 1) Try Consumet providers (use title->slug to lookup)
-    try {
-      const infoShort = await tryFetchJson(`${JIKAN_BASE}/anime/${id}`).catch(
-        () => null,
-      );
-      const title =
-        infoShort?.data?.title ||
-        infoShort?.data?.title_english ||
-        infoShort?.data?.title_japanese;
-      if (title) {
-        const slug = slugify(title);
-        const CONSUMET = "https://api.consumet.org";
-        const providers = ["gogoanime", "zoro", "animepahe"];
-        for (const p of providers) {
-          try {
-            const url = `${CONSUMET}/anime/${p}/info/${slug}`;
-            const jC = await tryFetchJson(url);
-            const arr =
-              jC?.episodes ||
-              jC?.results ||
-              jC?.data?.episodes ||
-              jC?.data ||
-              null;
-            if (Array.isArray(arr) && arr.length > 0) {
-              const episodes = arr.map((ep: any) => {
-                const number =
-                  ep.number ??
-                  ep.episode ??
-                  ep.ep ??
-                  ep.ep_num ??
-                  ep.index ??
-                  null;
-                const title =
-                  ep.title ||
-                  ep.name ||
-                  ep.episodeTitle ||
-                  ep.title_english ||
-                  null;
-                const air_date = ep.air_date ?? ep.aired ?? ep.date ?? null;
-                const eid = ep.id ?? ep.mal_id ?? `${id}-${number ?? "0"}`;
-                return {
-                  id: String(eid),
-                  number:
-                    typeof number === "number" ? number : Number(number) || 0,
-                  title: title || undefined,
-                  air_date,
-                };
-              });
-              // compute pagination details if available
-              const per_page =
-                jC?.pagination?.items?.per_page ||
-                jC?.pagination?.limit ||
-                jC?.meta?.perPage ||
-                24;
-              const total =
-                jC?.pagination?.items?.total ||
-                jC?.meta?.total ||
-                jC?.total ||
-                jC?.count ||
-                null;
-              const last_visible_page =
-                total && per_page
-                  ? Math.ceil(total / per_page)
-                  : Math.max(1, Math.ceil((arr?.length || 0) / per_page));
-              const pagination = {
-                page: jC?.pagination?.current_page || page,
-                has_next_page: !!(
-                  jC?.pagination?.has_next_page ||
-                  (total && per_page ? page * per_page < total : false)
-                ),
-                last_visible_page,
-              };
-              return res.json({ episodes, pagination });
-            }
-          } catch (e) {
-            // ignore provider errors
-          }
-        }
-      }
-    } catch (e) {
-      console.warn("consumet episodes fetch failed", String(e));
+    const r = await fetch(`${JIKAN_BASE}/anime/${id}/episodes?page=${page}`);
+    if (!r.ok) {
+      return res.status(r.status).json({ episodes: [], pagination: null });
     }
+    const json = await r.json();
 
-    // 2) Try dexter API with timeout/retries
-    try {
-      const jikanUrl = `${JIKAN_BASE}/anime/${id}/episodes?page=${page}`;
-      const json = await tryFetchJson(jikanUrl);
-      const episodes = (json.data || []).map((ep: any) => ({
-        id: String(ep.mal_id ?? `${id}-${ep.episode ?? ""}`),
-        number:
-          typeof ep.episode === "number" ? ep.episode : Number(ep.episode) || 0,
-        title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
-        air_date: ep.aired || null,
-      }));
-      const pagination = json.pagination || null;
-      if (episodes.length > 0) return res.json({ episodes, pagination });
-    } catch (e) {
-      console.warn("jikan episodes fetch failed", String(e));
-    }
+    const episodes = (json.data || []).map((ep: any) => ({
+      id: String(ep.mal_id ?? `${id}-${ep.episode ?? ""}`),
+      number:
+        typeof ep.episode === "number" ? ep.episode : Number(ep.episode) || 0,
+      title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
+      air_date: ep.aired || null,
+    }));
 
-    // 3) Fallback: attempt to fetch basic info and generate numbered episodes if episodes count available
-    try {
-      const infoUrl = `${JIKAN_BASE}/anime/${id}/full`;
-      const inf = await tryFetchJson(infoUrl).catch(() => null);
-      const epCount = inf?.data?.episodes ?? null;
-      if (typeof epCount === "number" && epCount > 0) {
-        const max = Math.min(epCount, 200);
-        const episodes = Array.from({ length: max }).map((_, i) => ({
-          id: `${id}-${i + 1}`,
-          number: i + 1,
-          title: undefined,
-          air_date: null,
-        }));
-        const per_page = 24;
-        const last_visible_page = Math.ceil(epCount / per_page);
-        return res.json({
-          episodes,
-          pagination: {
-            page: 1,
-            has_next_page: epCount > max,
-            last_visible_page,
-          },
-        });
-      }
-    } catch (e) {
-      console.warn("fallback info fetch failed", String(e));
-    }
-
-    // Nothing available
-    return res.json({ episodes: [], pagination: null });
+    const pagination = json.pagination || null;
+    return res.json({ episodes, pagination });
   } catch (e: any) {
     res.status(500).json({ error: e?.message || "Episodes failed" });
   }

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -258,13 +258,16 @@ export const getEpisodes: RequestHandler = async (req, res) => {
     const primary = await fetchJson(`${JIKAN_BASE}/anime/${id}/episodes?page=${page}`);
     if (primary.ok) {
       const j = primary.json as any;
-      const episodes = (j.data || []).map((ep: any) => ({
-        id: String(ep.mal_id ?? `${id}-${ep.episode ?? ""}`),
-        number:
-          typeof ep.episode === "number" ? ep.episode : Number(ep.episode) || 0,
-        title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
-        air_date: ep.aired || null,
-      }));
+      const episodes = (j.data || []).map((ep: any, idx: number) => {
+        const numRaw = ep.episode;
+        const num = typeof numRaw === "number" ? numRaw : Number(numRaw) || 0;
+        return {
+          id: String(ep.mal_id ?? `${id}-${num || idx + 1}`),
+          number: num > 0 ? num : idx + 1,
+          title: ep.title || ep.title_romanji || ep.title_japanese || undefined,
+          air_date: ep.aired || null,
+        };
+      });
       const payload = { episodes, pagination: j.pagination || null };
       // Cache even empty to avoid hammering the API
       episodesCache[cacheKey] = { at: now, data: payload };

--- a/server/routes/anime.ts
+++ b/server/routes/anime.ts
@@ -20,19 +20,24 @@ function normalizeBaseTitle(title: string) {
 
 function mapAnime(a: any) {
   const images = a.images?.jpg || a.images?.webp || {};
-  const baseTitle = normalizeBaseTitle(
-    a.title || a.title_english || a.title_japanese,
-  );
+  const originalTitle = a.title || a.title_english || a.title_japanese || "";
+  const baseTitle = normalizeBaseTitle(originalTitle);
+  const nowYear = new Date().getFullYear();
+  const year = a.year ?? a.aired?.prop?.from?.year ?? null;
+  const airing = a.airing === true || a.status === "Currently Airing";
+  const seasonMarker = /(season\s*\d+|part\s*\d+|cour\s*\d+|final\s*season|\bii\b|\biii\b|\biv\b|\bv\b|\bvi\b|\bvii\b|\bviii\b|\bix\b|\bx\b|\d+\s*$)/i.test(originalTitle);
+  const isNewSeason = seasonMarker && (airing || (year === nowYear));
   return {
     id: a.mal_id,
     title: baseTitle,
     image: images.large_image_url || images.image_url || images.small_image_url,
     type: a.type || undefined,
-    year: a.year ?? a.aired?.prop?.from?.year ?? null,
+    year,
     rating: typeof a.score === "number" ? a.score : null,
     subDub: "SUB",
     genres: Array.isArray(a.genres) ? a.genres.map((g: any) => g.name) : [],
     synopsis: a.synopsis || "",
+    isNewSeason,
   };
 }
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several critical issues with the anime application:
- Users reported episodes showing as "0" and missing episode data for seasonal variants
- Banner display was too large and expanding into episode sections
- Need for visual indicators when new seasons are available
- Streaming links showing "not available" errors
- Inaccurate episode numbering and data retrieval

## Code changes

### Frontend improvements:
- **AnimeCard**: Added `isNewSeason` property and yellow "New Season" tag display alongside genre tags
- **Anime page**: Redesigned banner layout with proper height constraints (h-48/56/64) and improved gradient overlay
- **Season handling**: Implemented proper season selection logic with `selectedId` state management
- **Episode numbering**: Fixed episode numbering fallback to use array index + 1 when API returns 0

### Backend API enhancements:
- **Episodes endpoint**: Complete rewrite with caching mechanism and improved error handling
- **Data sources**: Streamlined to use Jikan as primary source with Consumet as fallback
- **Episode normalization**: Enhanced episode number calculation to prevent "0" episodes
- **Caching**: Added episode caching with TTL to reduce API calls and improve performance
- **Error handling**: Improved timeout handling and retry logic for 429 responses

### UI/UX fixes:
- Reduced banner height and prevented expansion into episode sections
- Better responsive design for banner images
- Improved loading states and error messaging
- Enhanced season selection workflowTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0b98d8e47270412a9351c05d21d044ad/pulse-haven)

👀 [Preview Link](https://0b98d8e47270412a9351c05d21d044ad-pulse-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b98d8e47270412a9351c05d21d044ad</projectId>-->
<!--<branchName>pulse-haven</branchName>-->